### PR TITLE
added PR labeler for fronted,docs,workflow etc changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+# Add 'frontend' label for UI changes
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/**'
+          - 'components/**'
+          - 'public/**'
+          - 'styles/**'
+
+# Add 'documentation' label for markdown files
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - '**/*.txt'
+
+# Add 'ci-cd' label for GitHub workflow changes
+ci-cd:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+# Add 'config' label for package updates or config changes
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'package-lock.json'
+          - '*.config.js'
+          - '*.config.mjs'
+          - '*.config.ts'
+          

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,20 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Labeler
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true # Removes labels if files are removed from the PR
+          


### PR DESCRIPTION
## Summary
This PR adds a workflow to automatically categorize Pull Requests with labels based on the files changed.

## Changes
- **Workflow (`.github/workflows/pr-labeler.yml`):** Runs the `actions/labeler` action on PRs.
- **Config (`.github/labeler.yml`):** Defines the following rules:
  - `components/**`, `app/**`, `public/**` → `frontend`
  - `**/*.md` → `documentation`
  - `.github/**` → `ci-cd`
  - Config files & `package.json` → `config`

## Motivation
Automatic labeling helps triagers quickly identify the scope of a PR (e.g., distinguishing a simple documentation fix from a complex frontend refactor) without manual intervention.

## Verification
- [x] Open a dummy PR changing `README.md` and verify the `documentation` label is applied automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated pull request labeling based on changed files to improve code organization and review tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->