### PR TITLE
Fix: Apply correct dark mode theme text colors in CTASection

### DIFF
--- a/components/CTASection.tsx
+++ b/components/CTASection.tsx
@@ -18,11 +18,11 @@ const CTASection = () => {
           }}
         />
 
-        <h2 className="mx-auto mt-8 max-w-[90%] px-4 font-utsaha text-2xl tracking-tight text-black md:mt-[72px] md:max-w-[768px] md:px-0 md:text-6xl">
+        <h2 className="mx-auto mt-8 max-w-[90%] px-4 font-utsaha text-2xl tracking-tight text-black md:mt-[72px] md:max-w-[768px] md:px-0 md:text-6xl dark:text-white">
           By Stability Nexus, For Everyone
         </h2>
 
-        <p className="mt-5 px-4 font-utsaha text-lg text-black md:mt-[24px] md:text-2xl">
+        <p className="mt-5 px-4 font-utsaha text-lg text-black md:mt-[24px] md:text-2xl dark:text-white">
           Mint your Decentralized ID today
         </p>
 


### PR DESCRIPTION
Applies `dark:text-white` utility classes to the heading and description elements in the CTASection to maintain visibility against the dark background.\n\nFixes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode text colors for improved readability in the call-to-action section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->