### PR TITLE
Fix: Add dark mode classes to error and loading states

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -10,15 +10,17 @@ export default function ErrorPage({
   reset: () => void;
 }) {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-landing-bg p-4 text-center">
-      <h2 className="text-xl font-medium tracking-tight text-gray-900">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-landing-bg p-4 text-center dark:bg-landing-bg-dark">
+      <h2 className="text-xl font-medium tracking-tight text-gray-900 dark:text-landhead-text-dark">
         Something went wrong
       </h2>
-      <p className="mt-2 text-sm text-gray-600">{error.message}</p>
+      <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+        {error.message}
+      </p>
       <button
         type="button"
         onClick={reset}
-        className="mt-6 rounded-[24.85px] border border-gray-300 bg-white px-6 py-3 text-base text-gray-700 transition-colors hover:bg-gray-50 focus:ring-2 focus:ring-brand-blue/20 focus:outline-none"
+        className="mt-6 rounded-[24.85px] border border-gray-300 bg-white px-6 py-3 text-base text-gray-700 transition-colors hover:bg-gray-50 focus:ring-2 focus:ring-brand-blue/20 focus:outline-none dark:border-gray-700 dark:bg-step-card dark:text-gray-200 dark:hover:bg-gray-800"
       >
         Try again
       </button>

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-landing-bg">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-landing-bg dark:bg-landing-bg-dark">
       <div className="h-8 w-8 animate-spin rounded-full border-2 border-brand-blue border-t-transparent" />
     </div>
   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,11 +2,11 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-landing-bg p-4 text-center">
-      <h2 className="text-3xl font-bold tracking-tight text-gray-900">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-landing-bg p-4 text-center dark:bg-landing-bg-dark">
+      <h2 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-landhead-text-dark">
         404 - Not Found
       </h2>
-      <p className="mt-4 text-lg text-gray-600">
+      <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
         Could not find the requested resource.
       </p>
       <Link


### PR DESCRIPTION
Applies required `dark:` tailwind utility classes to `error.tsx`, `not-found.tsx`, and `loading.tsx` ensuring full dark mode support across these auxiliary pages.\n\nFixes #59