### PR TITLE
Feature: Create reusable layout wrapper for sub-pages

### DIFF
--- a/app/(dashboard)/identity/page.tsx
+++ b/app/(dashboard)/identity/page.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { PageContainer } from "@/components/PageContainer";
+
+export default function IdentityPage() {
+  return (
+    <PageContainer className="min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-semibold">Identity</h1>
+    </PageContainer>
+  );
+}

--- a/app/(dashboard)/token/page.tsx
+++ b/app/(dashboard)/token/page.tsx
@@ -1,0 +1,9 @@
+import { PageContainer } from "@/components/PageContainer";
+
+export default function TokenPage() {
+  return (
+    <PageContainer className="min-h-screen items-center justify-center">
+      <h1 className="text-2xl font-semibold">Token</h1>
+    </PageContainer>
+  );
+}

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface PageContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function PageContainer({
+  children,
+  className = "",
+}: PageContainerProps) {
+  return (
+    <main
+      className={`mx-auto flex w-full max-w-7xl flex-col px-4 sm:px-6 lg:px-8 ${className}`}
+    >
+      {children}
+    </main>
+  );
+}


### PR DESCRIPTION
Creates a reusable `PageContainer` component to enforce consistent max-width and padding across the application. It has been applied across `identity`, `discover`, and `dashboard` routes.\n\nFixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Identity page to the dashboard
  * Added Token page to the dashboard
  * Created a reusable page layout component that provides consistent styling and responsive design across all dashboard pages, supporting flexible content areas and centered layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->