### PR TITLE
feat: add contract ABI, config, and wagmi hooks integration layer

### DIFF
--- a/lib/abi/TNT.abi.json
+++ b/lib/abi/TNT.abi.json
@@ -1,0 +1,1270 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "MAX_ATTRIBUTE_SIZE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_PAGE_SIZE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "burn",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "confirmBackupUpdate",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getApproved",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAttribute",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "keyHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEndorsementCount",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEndorsements",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "start",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "end",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct DataTypes.Endorsement[]",
+        "components": [
+          {
+            "name": "endorserTokenId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "connectionType",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "timestamp",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "validUntil",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "revokedAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getGivenEndorsementCount",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getGivenEndorsements",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "start",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "end",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct DataTypes.GivenEndorsement[]",
+        "components": [
+          {
+            "name": "toTokenId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "endorsementIndex",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getIdentityState",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DataTypes.IdentityState",
+        "components": [
+          {
+            "name": "isCompromised",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "backupWallet",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "pendingBackupWallet",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "backupUnlockTime",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "giveEndorsement",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "typeHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "expiry",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "identityState",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isCompromised",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "backupWallet",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "pendingBackupWallet",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "backupUnlockTime",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initiateBackupUpdate",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newBackup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isApprovedForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isEndorsementActive",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "issueToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "markCompromised",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownerOf",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "recoverIdentity",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "revokeEndorsement",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setApprovalForAll",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setAttribute",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "keyHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "value",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setTokenURI",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "uri",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokenIssuers",
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokenURI",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ApprovalForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AttributeSet",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "keyHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "value",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BackupUpdateInitiated",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newBackup",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "unlockTime",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BackupUpdated",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newBackup",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EndorsementGiven",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "typeHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "expiry",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EndorsementRevoked",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IdentityCompromiseCleared",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IdentityCompromised",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IdentityCreated",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IdentityRecovered",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TokenURISet",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "uri",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AlreadyEndorsed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AlreadyRevoked",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC721IncorrectOwner",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InsufficientApproval",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidApprover",
+    "inputs": [
+      {
+        "name": "approver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidOperator",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidSender",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721NonexistentToken",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "IdentityCompromised",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "IndexOutOfBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoPendingUpdate",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotBackupWallet",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotEndorser",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotTokenOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "OwnableInvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OwnableUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "PageTooLarge",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SelfEndorsement",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TargetInvalid",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TimelockActive",
+    "inputs": []
+  }
+]

--- a/lib/abi/TNT.client.abi.json
+++ b/lib/abi/TNT.client.abi.json
@@ -1,0 +1,631 @@
+[
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getApproved",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAttribute",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "keyHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEndorsementCount",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEndorsements",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "start",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "end",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct DataTypes.Endorsement[]",
+        "components": [
+          {
+            "name": "endorserTokenId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "connectionType",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "timestamp",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "validUntil",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "revokedAt",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getGivenEndorsementCount",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getGivenEndorsements",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "start",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "end",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple[]",
+        "internalType": "struct DataTypes.GivenEndorsement[]",
+        "components": [
+          {
+            "name": "toTokenId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "endorsementIndex",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getIdentityState",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct DataTypes.IdentityState",
+        "components": [
+          {
+            "name": "isCompromised",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "backupWallet",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "pendingBackupWallet",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "backupUnlockTime",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "giveEndorsement",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "typeHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "expiry",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isApprovedForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "issueToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "ownerOf",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "revokeEndorsement",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setAttribute",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "keyHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "value",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setTokenURI",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "uri",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "tokenURI",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "AttributeSet",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "keyHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "value",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EndorsementGiven",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "typeHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "expiry",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EndorsementRevoked",
+    "inputs": [
+      {
+        "name": "fromId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "toId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "index",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IdentityCreated",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TokenURISet",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "uri",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AlreadyEndorsed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AlreadyRevoked",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721NonexistentToken",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "IdentityCompromised",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "IndexOutOfBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotTokenOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PageTooLarge",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SelfEndorsement",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TargetInvalid",
+    "inputs": []
+  }
+]

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -1,0 +1,34 @@
+/**
+ * Contract addresses for the TNT (Trust Network Token) contract per chain.
+ *
+ * Update each address after deployment. `0x0` means not yet deployed on that network.
+ * Chain IDs follow viem/wagmi conventions:
+ *   mainnet  = 1
+ *   sepolia  = 11155111
+ *   polygon  = 137
+ *   optimism = 10
+ *   arbitrum = 42161
+ *   base     = 8453
+ */
+
+export const TNT_ADDRESSES: Record<number, `0x${string}`> = {
+  1: "0x0000000000000000000000000000000000000000", // Ethereum mainnet — not deployed yet
+  11155111: "0x0000000000000000000000000000000000000000", // Sepolia testnet — update after deployment
+  137: "0x0000000000000000000000000000000000000000", // Polygon
+  10: "0x0000000000000000000000000000000000000000", // Optimism
+  42161: "0x0000000000000000000000000000000000000000", // Arbitrum One
+  8453: "0x0000000000000000000000000000000000000000", // Base
+} as const;
+
+/**
+ * Returns the TNT contract address for a given chain ID,
+ * or undefined if no address is configured for that chain.
+ */
+export function getTNTAddress(chainId: number): `0x${string}` | undefined {
+  const addr = TNT_ADDRESSES[chainId];
+  // Treat the zero address as "not deployed"
+  if (!addr || addr === "0x0000000000000000000000000000000000000000") {
+    return undefined;
+  }
+  return addr;
+}

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,0 +1,17 @@
+// Write hooks — send transactions
+export { useIssueIdentityToken } from "./useIssueIdentityToken";
+export { useSetAttribute, attributeKeyHash } from "./useSetAttribute";
+export type { KnownAttributeKey } from "./useSetAttribute";
+export { useSetTokenURI } from "./useSetTokenURI";
+export { useEndorseIdentity } from "./useEndorseIdentity";
+export { useRevokeEndorsement } from "./useRevokeEndorsement";
+
+// Read hooks — pure on-chain queries
+export { useGetEndorsements, useGetEndorsementCount } from "./useGetEndorsements";
+export type { Endorsement } from "./useGetEndorsements";
+export { useGetGivenEndorsements, useGetGivenEndorsementCount } from "./useGetGivenEndorsements";
+export type { GivenEndorsement } from "./useGetGivenEndorsements";
+export { useGetIdentityState } from "./useGetIdentityState";
+export type { IdentityState } from "./useGetIdentityState";
+export { useGetAttribute } from "./useGetAttribute";
+export { useTokenURI } from "./useTokenURI";

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -7,9 +7,15 @@ export { useEndorseIdentity } from "./useEndorseIdentity";
 export { useRevokeEndorsement } from "./useRevokeEndorsement";
 
 // Read hooks — pure on-chain queries
-export { useGetEndorsements, useGetEndorsementCount } from "./useGetEndorsements";
+export {
+  useGetEndorsements,
+  useGetEndorsementCount,
+} from "./useGetEndorsements";
 export type { Endorsement } from "./useGetEndorsements";
-export { useGetGivenEndorsements, useGetGivenEndorsementCount } from "./useGetGivenEndorsements";
+export {
+  useGetGivenEndorsements,
+  useGetGivenEndorsementCount,
+} from "./useGetGivenEndorsements";
 export type { GivenEndorsement } from "./useGetGivenEndorsements";
 export { useGetIdentityState } from "./useGetIdentityState";
 export type { IdentityState } from "./useGetIdentityState";

--- a/lib/hooks/useEndorseIdentity.ts
+++ b/lib/hooks/useEndorseIdentity.ts
@@ -1,8 +1,12 @@
 "use client";
 
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import {
+  useWriteContract,
+  useWaitForTransactionReceipt,
+  useChainId,
+} from "wagmi";
 import { type Hex } from "viem";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 /**
@@ -16,47 +20,65 @@ import { getTNTAddress } from "@/lib/contracts";
  *   giveEndorsement({ fromId: 1n, toId: 2n, connectionType: "colleague", expiry: 0n });
  */
 export function useEndorseIdentity() {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { writeContract, data: hash, isPending, error } = useWriteContract();
+  const { writeContract, data: hash, isPending, error } = useWriteContract();
 
-    const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+  const {
+    isLoading: isConfirming,
+    isSuccess,
+    error: receiptError,
+  } = useWaitForTransactionReceipt({ hash });
 
-    function giveEndorsement({
-        fromId,
-        toId,
-        connectionType,
-        expiry = BigInt(0),
-    }: {
-        fromId: bigint;
-        toId: bigint;
-        /**
-         * A plain string label (e.g. "colleague", "friend") that will be right-zero-
-         * padded to bytes32, or a raw 0x-prefixed bytes32 hex string.
-         */
-        connectionType: string;
-        expiry?: bigint;
-    }) {
-        if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
+  function giveEndorsement({
+    fromId,
+    toId,
+    connectionType,
+    expiry = BigInt(0),
+  }: {
+    fromId: bigint;
+    toId: bigint;
+    /**
+     * A plain string label (e.g. "colleague", "friend") that will be right-zero-
+     * padded to bytes32, or a raw 0x-prefixed bytes32 hex string.
+     */
+    connectionType: string;
+    expiry?: bigint;
+  }) {
+    if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
 
-        const typeHash: Hex =
-            connectionType.startsWith("0x") && connectionType.length === 66
-                ? (connectionType as Hex)
-                : ((() => {
-                    const bytes = new TextEncoder().encode(connectionType);
-                    const padded = new Uint8Array(32);
-                    padded.set(bytes.slice(0, 32));
-                    return ("0x" + [...padded].map((b) => b.toString(16).padStart(2, "0")).join("")) as Hex;
-                })());
-
-        writeContract({
-            address,
-            abi: TNT_ABI,
-            functionName: "giveEndorsement",
-            args: [fromId, toId, typeHash, expiry],
-        });
+    let typeHash: Hex;
+    if (connectionType.startsWith("0x") && connectionType.length === 66) {
+      typeHash = connectionType as Hex;
+    } else {
+      const bytes = new TextEncoder().encode(connectionType);
+      if (bytes.length > 32) {
+        throw new Error(
+          `connectionType "${connectionType}" encodes to ${bytes.length} bytes; max is 32 bytes`
+        );
+      }
+      const padded = new Uint8Array(32);
+      padded.set(bytes);
+      typeHash = ("0x" +
+        [...padded]
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("")) as Hex;
     }
 
-    return { giveEndorsement, hash, isPending: isPending || isConfirming, isSuccess, error } as const;
+    writeContract({
+      address,
+      abi: CLIENT_ABI,
+      functionName: "giveEndorsement",
+      args: [fromId, toId, typeHash, expiry],
+    });
+  }
+
+  return {
+    giveEndorsement,
+    hash,
+    isPending: isPending || isConfirming,
+    isSuccess,
+    error: error ?? receiptError,
+  } as const;
 }

--- a/lib/hooks/useEndorseIdentity.ts
+++ b/lib/hooks/useEndorseIdentity.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { type Hex } from "viem";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+/**
+ * Hook: give an on-chain endorsement from one DIT token to another.
+ *
+ * Caller must own `fromId`. `toId` must not be compromised.
+ * Pass `expiry = 0n` for a permanent endorsement.
+ *
+ * Usage:
+ *   const { giveEndorsement, isPending } = useEndorseIdentity();
+ *   giveEndorsement({ fromId: 1n, toId: 2n, connectionType: "colleague", expiry: 0n });
+ */
+export function useEndorseIdentity() {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { writeContract, data: hash, isPending, error } = useWriteContract();
+
+    const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+
+    function giveEndorsement({
+        fromId,
+        toId,
+        connectionType,
+        expiry = BigInt(0),
+    }: {
+        fromId: bigint;
+        toId: bigint;
+        /**
+         * A plain string label (e.g. "colleague", "friend") that will be right-zero-
+         * padded to bytes32, or a raw 0x-prefixed bytes32 hex string.
+         */
+        connectionType: string;
+        expiry?: bigint;
+    }) {
+        if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
+
+        const typeHash: Hex =
+            connectionType.startsWith("0x") && connectionType.length === 66
+                ? (connectionType as Hex)
+                : ((() => {
+                    const bytes = new TextEncoder().encode(connectionType);
+                    const padded = new Uint8Array(32);
+                    padded.set(bytes.slice(0, 32));
+                    return ("0x" + [...padded].map((b) => b.toString(16).padStart(2, "0")).join("")) as Hex;
+                })());
+
+        writeContract({
+            address,
+            abi: TNT_ABI,
+            functionName: "giveEndorsement",
+            args: [fromId, toId, typeHash, expiry],
+        });
+    }
+
+    return { giveEndorsement, hash, isPending: isPending || isConfirming, isSuccess, error } as const;
+}

--- a/lib/hooks/useGetAttribute.ts
+++ b/lib/hooks/useGetAttribute.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useReadContract, useChainId } from "wagmi";
+import { type Hex } from "viem";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+/**
+ * Hook: read a single attribute from a DIT token and decode it as UTF-8 text.
+ *
+ * Pass `key` as a plain string (e.g. "name", "twitter") — the hook hashes it
+ * the same way `useSetAttribute` does.
+ *
+ * Usage:
+ *   const { value } = useGetAttribute({ tokenId: 1n, key: "name" });
+ *   // value === "Alice"
+ */
+export function useGetAttribute({
+    tokenId,
+    key,
+}: {
+    tokenId: bigint | undefined;
+    key: string;
+}) {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const keyHash: Hex = (() => {
+        if (key.startsWith("0x") && key.length === 66) return key as Hex;
+        const bytes = new TextEncoder().encode(key);
+        const padded = new Uint8Array(32);
+        padded.set(bytes.slice(0, 32));
+        return ("0x" + [...padded].map((b) => b.toString(16).padStart(2, "0")).join("")) as Hex;
+    })();
+
+    const { data, isLoading, error, refetch } = useReadContract({
+        address,
+        abi: TNT_ABI,
+        functionName: "getAttribute",
+        args: [tokenId!, keyHash],
+        query: { enabled: !!address && tokenId !== undefined && !!key },
+    });
+
+    // data is raw bytes from the contract; decode as UTF-8 string
+    const value =
+        data && (data as `0x${string}`).length > 2
+            ? new TextDecoder().decode(
+                Uint8Array.from(
+                    Buffer.from((data as string).slice(2), "hex"),
+                ),
+            )
+            : undefined;
+
+    return { value, raw: data as `0x${string}` | undefined, isLoading, error, refetch } as const;
+}

--- a/lib/hooks/useGetAttribute.ts
+++ b/lib/hooks/useGetAttribute.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useReadContract, useChainId } from "wagmi";
-import { type Hex } from "viem";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { hexToBytes, type Hex } from "viem";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
+import { attributeKeyHash } from "@/lib/hooks/useSetAttribute";
 
 /**
  * Hook: read a single attribute from a DIT token and decode it as UTF-8 text.
@@ -16,40 +17,43 @@ import { getTNTAddress } from "@/lib/contracts";
  *   // value === "Alice"
  */
 export function useGetAttribute({
-    tokenId,
-    key,
+  tokenId,
+  key,
 }: {
-    tokenId: bigint | undefined;
-    key: string;
+  tokenId: bigint | undefined;
+  key: string;
 }) {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const keyHash: Hex = (() => {
-        if (key.startsWith("0x") && key.length === 66) return key as Hex;
-        const bytes = new TextEncoder().encode(key);
-        const padded = new Uint8Array(32);
-        padded.set(bytes.slice(0, 32));
-        return ("0x" + [...padded].map((b) => b.toString(16).padStart(2, "0")).join("")) as Hex;
-    })();
+  const keyHash: Hex =
+    key.startsWith("0x") && key.length === 66
+      ? (key as Hex)
+      : attributeKeyHash(key);
 
-    const { data, isLoading, error, refetch } = useReadContract({
-        address,
-        abi: TNT_ABI,
-        functionName: "getAttribute",
-        args: [tokenId!, keyHash],
-        query: { enabled: !!address && tokenId !== undefined && !!key },
-    });
+  const { data, isLoading, error, refetch } = useReadContract({
+    address,
+    abi: CLIENT_ABI,
+    functionName: "getAttribute",
+    args: [tokenId!, keyHash],
+    query: { enabled: !!address && tokenId !== undefined && !!key },
+  });
 
-    // data is raw bytes from the contract; decode as UTF-8 string
-    const value =
-        data && (data as `0x${string}`).length > 2
-            ? new TextDecoder().decode(
-                Uint8Array.from(
-                    Buffer.from((data as string).slice(2), "hex"),
-                ),
-            )
-            : undefined;
+  // data is raw bytes from the contract; decode as UTF-8 string
+  const value =
+    data && (data as `0x${string}`).length > 2
+      ? new TextDecoder().decode(
+          new Uint8Array(
+            hexToBytes((data as `0x${string}`).slice(2) as `0x${string}`)
+          )
+        )
+      : undefined;
 
-    return { value, raw: data as `0x${string}` | undefined, isLoading, error, refetch } as const;
+  return {
+    value,
+    raw: data as `0x${string}` | undefined,
+    isLoading,
+    error,
+    refetch,
+  } as const;
 }

--- a/lib/hooks/useGetEndorsements.ts
+++ b/lib/hooks/useGetEndorsements.ts
@@ -1,15 +1,15 @@
 "use client";
 
 import { useReadContract, useChainId } from "wagmi";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 export interface Endorsement {
-    endorserTokenId: bigint;
-    connectionType: `0x${string}`;
-    timestamp: bigint;
-    validUntil: bigint;
-    revokedAt: bigint;
+  endorserTokenId: bigint;
+  connectionType: `0x${string}`;
+  timestamp: bigint;
+  validUntil: bigint;
+  revokedAt: bigint;
 }
 
 /**
@@ -22,31 +22,34 @@ export interface Endorsement {
  *   const { endorsements, isLoading } = useGetEndorsements({ tokenId: 2n, start: 0n, end: 20n });
  */
 export function useGetEndorsements({
-    tokenId,
-    start = BigInt(0),
-    end = BigInt(20),
+  tokenId,
+  start = BigInt(0),
+  end,
 }: {
-    tokenId: bigint | undefined;
-    start?: bigint;
-    end?: bigint;
+  tokenId: bigint | undefined;
+  start?: bigint;
+  end?: bigint;
 }) {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { data, isLoading, error, refetch } = useReadContract({
-        address,
-        abi: TNT_ABI,
-        functionName: "getEndorsements",
-        args: [tokenId!, start, end],
-        query: { enabled: !!address && tokenId !== undefined },
-    });
+  const pageSize = BigInt(20);
+  const effectiveEnd = end ?? start + pageSize;
 
-    return {
-        endorsements: (data as Endorsement[] | undefined) ?? [],
-        isLoading,
-        error,
-        refetch,
-    } as const;
+  const { data, isLoading, error, refetch } = useReadContract({
+    address,
+    abi: CLIENT_ABI,
+    functionName: "getEndorsements",
+    args: [tokenId!, start, effectiveEnd],
+    query: { enabled: !!address && tokenId !== undefined },
+  });
+
+  return {
+    endorsements: (data as Endorsement[] | undefined) ?? [],
+    isLoading,
+    error,
+    refetch,
+  } as const;
 }
 
 /**
@@ -54,16 +57,16 @@ export function useGetEndorsements({
  * Use this to drive pagination for `useGetEndorsements`.
  */
 export function useGetEndorsementCount(tokenId: bigint | undefined) {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { data, isLoading, error } = useReadContract({
-        address,
-        abi: TNT_ABI,
-        functionName: "getEndorsementCount",
-        args: [tokenId!],
-        query: { enabled: !!address && tokenId !== undefined },
-    });
+  const { data, isLoading, error } = useReadContract({
+    address,
+    abi: CLIENT_ABI,
+    functionName: "getEndorsementCount",
+    args: [tokenId!],
+    query: { enabled: !!address && tokenId !== undefined },
+  });
 
-    return { count: data as bigint | undefined, isLoading, error } as const;
+  return { count: data as bigint | undefined, isLoading, error } as const;
 }

--- a/lib/hooks/useGetEndorsements.ts
+++ b/lib/hooks/useGetEndorsements.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useReadContract, useChainId } from "wagmi";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+export interface Endorsement {
+    endorserTokenId: bigint;
+    connectionType: `0x${string}`;
+    timestamp: bigint;
+    validUntil: bigint;
+    revokedAt: bigint;
+}
+
+/**
+ * Hook: read a paginated slice of endorsements RECEIVED by a DIT token.
+ *
+ * Returns all endorsements (including revoked ones — check `revokedAt !== 0n`).
+ * For large tokens, paginate using `start`/`end`.
+ *
+ * Usage:
+ *   const { endorsements, isLoading } = useGetEndorsements({ tokenId: 2n, start: 0n, end: 20n });
+ */
+export function useGetEndorsements({
+    tokenId,
+    start = BigInt(0),
+    end = BigInt(20),
+}: {
+    tokenId: bigint | undefined;
+    start?: bigint;
+    end?: bigint;
+}) {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { data, isLoading, error, refetch } = useReadContract({
+        address,
+        abi: TNT_ABI,
+        functionName: "getEndorsements",
+        args: [tokenId!, start, end],
+        query: { enabled: !!address && tokenId !== undefined },
+    });
+
+    return {
+        endorsements: (data as Endorsement[] | undefined) ?? [],
+        isLoading,
+        error,
+        refetch,
+    } as const;
+}
+
+/**
+ * Hook: read the total count of endorsements received by a token.
+ * Use this to drive pagination for `useGetEndorsements`.
+ */
+export function useGetEndorsementCount(tokenId: bigint | undefined) {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { data, isLoading, error } = useReadContract({
+        address,
+        abi: TNT_ABI,
+        functionName: "getEndorsementCount",
+        args: [tokenId!],
+        query: { enabled: !!address && tokenId !== undefined },
+    });
+
+    return { count: data as bigint | undefined, isLoading, error } as const;
+}

--- a/lib/hooks/useGetGivenEndorsements.ts
+++ b/lib/hooks/useGetGivenEndorsements.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useReadContract, useChainId } from "wagmi";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+export interface GivenEndorsement {
+    toTokenId: bigint;
+    endorsementIndex: bigint;
+}
+
+/**
+ * Hook: read endorsements GIVEN BY a DIT token (reverse index).
+ *
+ * Satisfies DIT spec: "efficient to retrieve which identities have been
+ * endorsed by a given identity".
+ *
+ * Each entry points back into the receiver's endorsement array at
+ * `endorsementIndex`, so you can cross-reference with `useGetEndorsements`
+ * for the full Endorsement struct.
+ *
+ * Usage:
+ *   const { givenEndorsements } = useGetGivenEndorsements({ tokenId: 1n, start: 0n, end: 20n });
+ */
+export function useGetGivenEndorsements({
+    tokenId,
+    start = BigInt(0),
+    end = BigInt(20),
+}: {
+    tokenId: bigint | undefined;
+    start?: bigint;
+    end?: bigint;
+}) {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { data, isLoading, error, refetch } = useReadContract({
+        address,
+        abi: TNT_ABI,
+        functionName: "getGivenEndorsements",
+        args: [tokenId!, start, end],
+        query: { enabled: !!address && tokenId !== undefined },
+    });
+
+    return {
+        givenEndorsements: (data as GivenEndorsement[] | undefined) ?? [],
+        isLoading,
+        error,
+        refetch,
+    } as const;
+}
+
+/**
+ * Hook: total count of endorsements given by a token.
+ * Use this to drive pagination for `useGetGivenEndorsements`.
+ */
+export function useGetGivenEndorsementCount(tokenId: bigint | undefined) {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { data, isLoading, error } = useReadContract({
+        address,
+        abi: TNT_ABI,
+        functionName: "getGivenEndorsementCount",
+        args: [tokenId!],
+        query: { enabled: !!address && tokenId !== undefined },
+    });
+
+    return { count: data as bigint | undefined, isLoading, error } as const;
+}

--- a/lib/hooks/useGetGivenEndorsements.ts
+++ b/lib/hooks/useGetGivenEndorsements.ts
@@ -1,12 +1,12 @@
 "use client";
 
 import { useReadContract, useChainId } from "wagmi";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 export interface GivenEndorsement {
-    toTokenId: bigint;
-    endorsementIndex: bigint;
+  toTokenId: bigint;
+  endorsementIndex: bigint;
 }
 
 /**
@@ -23,31 +23,34 @@ export interface GivenEndorsement {
  *   const { givenEndorsements } = useGetGivenEndorsements({ tokenId: 1n, start: 0n, end: 20n });
  */
 export function useGetGivenEndorsements({
-    tokenId,
-    start = BigInt(0),
-    end = BigInt(20),
+  tokenId,
+  start = BigInt(0),
+  end,
 }: {
-    tokenId: bigint | undefined;
-    start?: bigint;
-    end?: bigint;
+  tokenId: bigint | undefined;
+  start?: bigint;
+  end?: bigint;
 }) {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { data, isLoading, error, refetch } = useReadContract({
-        address,
-        abi: TNT_ABI,
-        functionName: "getGivenEndorsements",
-        args: [tokenId!, start, end],
-        query: { enabled: !!address && tokenId !== undefined },
-    });
+  const pageSize = BigInt(20);
+  const effectiveEnd = end ?? start + pageSize;
 
-    return {
-        givenEndorsements: (data as GivenEndorsement[] | undefined) ?? [],
-        isLoading,
-        error,
-        refetch,
-    } as const;
+  const { data, isLoading, error, refetch } = useReadContract({
+    address,
+    abi: CLIENT_ABI,
+    functionName: "getGivenEndorsements",
+    args: [tokenId!, start, effectiveEnd],
+    query: { enabled: !!address && tokenId !== undefined },
+  });
+
+  return {
+    givenEndorsements: (data as GivenEndorsement[] | undefined) ?? [],
+    isLoading,
+    error,
+    refetch,
+  } as const;
 }
 
 /**
@@ -55,16 +58,16 @@ export function useGetGivenEndorsements({
  * Use this to drive pagination for `useGetGivenEndorsements`.
  */
 export function useGetGivenEndorsementCount(tokenId: bigint | undefined) {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { data, isLoading, error } = useReadContract({
-        address,
-        abi: TNT_ABI,
-        functionName: "getGivenEndorsementCount",
-        args: [tokenId!],
-        query: { enabled: !!address && tokenId !== undefined },
-    });
+  const { data, isLoading, error } = useReadContract({
+    address,
+    abi: CLIENT_ABI,
+    functionName: "getGivenEndorsementCount",
+    args: [tokenId!],
+    query: { enabled: !!address && tokenId !== undefined },
+  });
 
-    return { count: data as bigint | undefined, isLoading, error } as const;
+  return { count: data as bigint | undefined, isLoading, error } as const;
 }

--- a/lib/hooks/useGetIdentityState.ts
+++ b/lib/hooks/useGetIdentityState.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useReadContract, useChainId } from "wagmi";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+export interface IdentityState {
+    isCompromised: boolean;
+    backupWallet: `0x${string}`;
+    pendingBackupWallet: `0x${string}`;
+    backupUnlockTime: bigint;
+}
+
+/**
+ * Hook: read the full identity state of a DIT token.
+ *
+ * Includes compromise status, current backup wallet, and pending timelock state.
+ *
+ * Usage:
+ *   const { state, isLoading } = useGetIdentityState(1n);
+ *   if (state?.isCompromised) { ... }
+ */
+export function useGetIdentityState(tokenId: bigint | undefined) {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { data, isLoading, error, refetch } = useReadContract({
+        address,
+        abi: TNT_ABI,
+        functionName: "getIdentityState",
+        args: [tokenId!],
+        query: { enabled: !!address && tokenId !== undefined },
+    });
+
+    return {
+        state: data as IdentityState | undefined,
+        isLoading,
+        error,
+        refetch,
+    } as const;
+}

--- a/lib/hooks/useGetIdentityState.ts
+++ b/lib/hooks/useGetIdentityState.ts
@@ -1,14 +1,14 @@
 "use client";
 
 import { useReadContract, useChainId } from "wagmi";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 export interface IdentityState {
-    isCompromised: boolean;
-    backupWallet: `0x${string}`;
-    pendingBackupWallet: `0x${string}`;
-    backupUnlockTime: bigint;
+  isCompromised: boolean;
+  backupWallet: `0x${string}`;
+  pendingBackupWallet: `0x${string}`;
+  backupUnlockTime: bigint;
 }
 
 /**
@@ -21,21 +21,21 @@ export interface IdentityState {
  *   if (state?.isCompromised) { ... }
  */
 export function useGetIdentityState(tokenId: bigint | undefined) {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { data, isLoading, error, refetch } = useReadContract({
-        address,
-        abi: TNT_ABI,
-        functionName: "getIdentityState",
-        args: [tokenId!],
-        query: { enabled: !!address && tokenId !== undefined },
-    });
+  const { data, isLoading, error, refetch } = useReadContract({
+    address,
+    abi: CLIENT_ABI,
+    functionName: "getIdentityState",
+    args: [tokenId!],
+    query: { enabled: !!address && tokenId !== undefined },
+  });
 
-    return {
-        state: data as IdentityState | undefined,
-        isLoading,
-        error,
-        refetch,
-    } as const;
+  return {
+    state: data as IdentityState | undefined,
+    isLoading,
+    error,
+    refetch,
+  } as const;
 }

--- a/lib/hooks/useIssueIdentityToken.ts
+++ b/lib/hooks/useIssueIdentityToken.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+/**
+ * Hook: issue a new DIT identity token to the connected wallet.
+ *
+ * DIT spec: "anyone can self-issue a token" — no arguments required;
+ * the contract mints directly to msg.sender.
+ *
+ * Usage:
+ *   const { issueToken, isPending, isSuccess, tokenId } = useIssueIdentityToken();
+ *   <button onClick={issueToken} disabled={isPending}>Mint Identity</button>
+ */
+export function useIssueIdentityToken() {
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
+
+  const { writeContract, data: hash, isPending, error } = useWriteContract();
+
+  const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+
+  function issueToken() {
+    if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
+    writeContract({
+      address,
+      abi: TNT_ABI,
+      functionName: "issueToken",
+    });
+  }
+
+  return {
+    issueToken,
+    hash,
+    isPending: isPending || isConfirming,
+    isSuccess,
+    error,
+  } as const;
+}

--- a/lib/hooks/useIssueIdentityToken.ts
+++ b/lib/hooks/useIssueIdentityToken.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import {
+  useWriteContract,
+  useWaitForTransactionReceipt,
+  useChainId,
+} from "wagmi";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 /**
@@ -20,13 +24,17 @@ export function useIssueIdentityToken() {
 
   const { writeContract, data: hash, isPending, error } = useWriteContract();
 
-  const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+  const {
+    isLoading: isConfirming,
+    isSuccess,
+    error: receiptError,
+  } = useWaitForTransactionReceipt({ hash });
 
   function issueToken() {
     if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
     writeContract({
       address,
-      abi: TNT_ABI,
+      abi: CLIENT_ABI,
       functionName: "issueToken",
     });
   }
@@ -36,6 +44,6 @@ export function useIssueIdentityToken() {
     hash,
     isPending: isPending || isConfirming,
     isSuccess,
-    error,
+    error: error ?? receiptError,
   } as const;
 }

--- a/lib/hooks/useRevokeEndorsement.ts
+++ b/lib/hooks/useRevokeEndorsement.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import {
+  useWriteContract,
+  useWaitForTransactionReceipt,
+  useChainId,
+} from "wagmi";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 /**
@@ -15,30 +19,40 @@ import { getTNTAddress } from "@/lib/contracts";
  *   revokeEndorsement({ fromId: 1n, toId: 2n, index: 0n });
  */
 export function useRevokeEndorsement() {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { writeContract, data: hash, isPending, error } = useWriteContract();
+  const { writeContract, data: hash, isPending, error } = useWriteContract();
 
-    const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+  const {
+    isLoading: isConfirming,
+    isSuccess,
+    error: receiptError,
+  } = useWaitForTransactionReceipt({ hash });
 
-    function revokeEndorsement({
-        fromId,
-        toId,
-        index,
-    }: {
-        fromId: bigint;
-        toId: bigint;
-        index: bigint;
-    }) {
-        if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
-        writeContract({
-            address,
-            abi: TNT_ABI,
-            functionName: "revokeEndorsement",
-            args: [fromId, toId, index],
-        });
-    }
+  function revokeEndorsement({
+    fromId,
+    toId,
+    index,
+  }: {
+    fromId: bigint;
+    toId: bigint;
+    index: bigint;
+  }) {
+    if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
+    writeContract({
+      address,
+      abi: CLIENT_ABI,
+      functionName: "revokeEndorsement",
+      args: [fromId, toId, index],
+    });
+  }
 
-    return { revokeEndorsement, hash, isPending: isPending || isConfirming, isSuccess, error } as const;
+  return {
+    revokeEndorsement,
+    hash,
+    isPending: isPending || isConfirming,
+    isSuccess,
+    error: error ?? receiptError,
+  } as const;
 }

--- a/lib/hooks/useRevokeEndorsement.ts
+++ b/lib/hooks/useRevokeEndorsement.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+/**
+ * Hook: revoke a previously given endorsement.
+ *
+ * Caller must own `fromId`. `index` is the position in the endorsement array
+ * for `toId` (use `useGetEndorsements` to find the correct index).
+ *
+ * Usage:
+ *   const { revokeEndorsement, isPending } = useRevokeEndorsement();
+ *   revokeEndorsement({ fromId: 1n, toId: 2n, index: 0n });
+ */
+export function useRevokeEndorsement() {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { writeContract, data: hash, isPending, error } = useWriteContract();
+
+    const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+
+    function revokeEndorsement({
+        fromId,
+        toId,
+        index,
+    }: {
+        fromId: bigint;
+        toId: bigint;
+        index: bigint;
+    }) {
+        if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
+        writeContract({
+            address,
+            abi: TNT_ABI,
+            functionName: "revokeEndorsement",
+            args: [fromId, toId, index],
+        });
+    }
+
+    return { revokeEndorsement, hash, isPending: isPending || isConfirming, isSuccess, error } as const;
+}

--- a/lib/hooks/useSetAttribute.ts
+++ b/lib/hooks/useSetAttribute.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { encodeAbiParameters, parseAbiParameters, type Hex } from "viem";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+export type KnownAttributeKey =
+  | "name"
+  | "twitter"
+  | "linkedin"
+  | "github"
+  | "nationality"
+  | "residence"
+  | "age_group";
+
+/**
+ * Returns the bytes32 key hash for a well-known attribute name.
+ * Matches the pattern used on-chain: keccak256(abi.encodePacked(key)).
+ */
+export function attributeKeyHash(key: string): Hex {
+  return encodeAbiParameters(parseAbiParameters("bytes32"), [
+    // viem's keccak256 of an ABI-encoded string is not the same as solidity's keccak256(abi.encodePacked(key))
+    // We use the raw bytes approach via TextEncoder to match Solidity's keccak256(bytes(key)).
+    (() => {
+      const bytes = new TextEncoder().encode(key);
+      // Pad to 32 bytes (right-zero-padded, which is how bytes32 literals work in Solidity)
+      const padded = new Uint8Array(32);
+      padded.set(bytes.slice(0, 32));
+      return ("0x" + [...padded].map((b) => b.toString(16).padStart(2, "0")).join("")) as Hex;
+    })(),
+  ]).slice(0, 66) as Hex; // keep only the bytes32 (66 hex chars incl. 0x)
+}
+
+/**
+ * Hook: set a single utf-8 attribute on a DIT token.
+ *
+ * The on-chain key is bytes32 (a keccak256 hash). Pass either a raw bytes32 hex
+ * string, or a plain string key (the hook will hash it for you).
+ *
+ * Usage:
+ *   const { setAttribute, isPending } = useSetAttribute();
+ *   setAttribute({ tokenId: 1n, key: "name", value: "Alice" });
+ */
+export function useSetAttribute() {
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
+
+  const { writeContract, data: hash, isPending, error } = useWriteContract();
+
+  const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+
+  function setAttribute({
+    tokenId,
+    key,
+    value,
+  }: {
+    tokenId: bigint;
+    /** Either a plain string (will be keccak256'd) or a raw 0x-prefixed bytes32. */
+    key: string;
+    value: string;
+  }) {
+    if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
+
+    const keyHash: Hex =
+      key.startsWith("0x") && key.length === 66
+        ? (key as Hex)
+        : attributeKeyHash(key);
+
+    const encoded = new TextEncoder().encode(value);
+
+    writeContract({
+      address,
+      abi: TNT_ABI,
+      functionName: "setAttribute",
+      args: [tokenId, keyHash, encoded],
+    });
+  }
+
+  return { setAttribute, hash, isPending: isPending || isConfirming, isSuccess, error } as const;
+}

--- a/lib/hooks/useSetAttribute.ts
+++ b/lib/hooks/useSetAttribute.ts
@@ -1,8 +1,12 @@
 "use client";
 
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
-import { encodeAbiParameters, parseAbiParameters, type Hex } from "viem";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import {
+  useWriteContract,
+  useWaitForTransactionReceipt,
+  useChainId,
+} from "wagmi";
+import { keccak256, toBytes, type Hex } from "viem";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 export type KnownAttributeKey =
@@ -15,21 +19,11 @@ export type KnownAttributeKey =
   | "age_group";
 
 /**
- * Returns the bytes32 key hash for a well-known attribute name.
- * Matches the pattern used on-chain: keccak256(abi.encodePacked(key)).
+ * Returns the bytes32 key hash for an attribute name.
+ * Matches Solidity's keccak256(abi.encodePacked(key)).
  */
 export function attributeKeyHash(key: string): Hex {
-  return encodeAbiParameters(parseAbiParameters("bytes32"), [
-    // viem's keccak256 of an ABI-encoded string is not the same as solidity's keccak256(abi.encodePacked(key))
-    // We use the raw bytes approach via TextEncoder to match Solidity's keccak256(bytes(key)).
-    (() => {
-      const bytes = new TextEncoder().encode(key);
-      // Pad to 32 bytes (right-zero-padded, which is how bytes32 literals work in Solidity)
-      const padded = new Uint8Array(32);
-      padded.set(bytes.slice(0, 32));
-      return ("0x" + [...padded].map((b) => b.toString(16).padStart(2, "0")).join("")) as Hex;
-    })(),
-  ]).slice(0, 66) as Hex; // keep only the bytes32 (66 hex chars incl. 0x)
+  return keccak256(toBytes(key));
 }
 
 /**
@@ -48,7 +42,11 @@ export function useSetAttribute() {
 
   const { writeContract, data: hash, isPending, error } = useWriteContract();
 
-  const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+  const {
+    isLoading: isConfirming,
+    isSuccess,
+    error: receiptError,
+  } = useWaitForTransactionReceipt({ hash });
 
   function setAttribute({
     tokenId,
@@ -71,11 +69,17 @@ export function useSetAttribute() {
 
     writeContract({
       address,
-      abi: TNT_ABI,
+      abi: CLIENT_ABI,
       functionName: "setAttribute",
       args: [tokenId, keyHash, encoded],
     });
   }
 
-  return { setAttribute, hash, isPending: isPending || isConfirming, isSuccess, error } as const;
+  return {
+    setAttribute,
+    hash,
+    isPending: isPending || isConfirming,
+    isSuccess,
+    error: error ?? receiptError,
+  } as const;
 }

--- a/lib/hooks/useSetTokenURI.ts
+++ b/lib/hooks/useSetTokenURI.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import {
+  useWriteContract,
+  useWaitForTransactionReceipt,
+  useChainId,
+} from "wagmi";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 /**
@@ -17,22 +21,32 @@ import { getTNTAddress } from "@/lib/contracts";
  *   setTokenURI({ tokenId: 1n, uri: "ipfs://Qm..." });
  */
 export function useSetTokenURI() {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { writeContract, data: hash, isPending, error } = useWriteContract();
+  const { writeContract, data: hash, isPending, error } = useWriteContract();
 
-    const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+  const {
+    isLoading: isConfirming,
+    isSuccess,
+    error: receiptError,
+  } = useWaitForTransactionReceipt({ hash });
 
-    function setTokenURI({ tokenId, uri }: { tokenId: bigint; uri: string }) {
-        if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
-        writeContract({
-            address,
-            abi: TNT_ABI,
-            functionName: "setTokenURI",
-            args: [tokenId, uri],
-        });
-    }
+  function setTokenURI({ tokenId, uri }: { tokenId: bigint; uri: string }) {
+    if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
+    writeContract({
+      address,
+      abi: CLIENT_ABI,
+      functionName: "setTokenURI",
+      args: [tokenId, uri],
+    });
+  }
 
-    return { setTokenURI, hash, isPending: isPending || isConfirming, isSuccess, error } as const;
+  return {
+    setTokenURI,
+    hash,
+    isPending: isPending || isConfirming,
+    isSuccess,
+    error: error ?? receiptError,
+  } as const;
 }

--- a/lib/hooks/useSetTokenURI.ts
+++ b/lib/hooks/useSetTokenURI.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+/**
+ * Hook: set (or update) the metadata URI for a DIT token.
+ *
+ * The URI should point to a JSON file conforming to the ERC-721 metadata standard:
+ * { "name": "...", "description": "...", "image": "...", "attributes": [...] }
+ *
+ * Typical URIs: "ipfs://Qm...", "https://api.example.com/tokens/1"
+ *
+ * Usage:
+ *   const { setTokenURI, isPending } = useSetTokenURI();
+ *   setTokenURI({ tokenId: 1n, uri: "ipfs://Qm..." });
+ */
+export function useSetTokenURI() {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { writeContract, data: hash, isPending, error } = useWriteContract();
+
+    const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });
+
+    function setTokenURI({ tokenId, uri }: { tokenId: bigint; uri: string }) {
+        if (!address) throw new Error(`TNT not deployed on chain ${chainId}`);
+        writeContract({
+            address,
+            abi: TNT_ABI,
+            functionName: "setTokenURI",
+            args: [tokenId, uri],
+        });
+    }
+
+    return { setTokenURI, hash, isPending: isPending || isConfirming, isSuccess, error } as const;
+}

--- a/lib/hooks/useTokenURI.ts
+++ b/lib/hooks/useTokenURI.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useReadContract, useChainId } from "wagmi";
+import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import { getTNTAddress } from "@/lib/contracts";
+
+/**
+ * Hook: read the ERC-721 tokenURI for a DIT token.
+ *
+ * Useful for loading off-chain or on-chain metadata JSON to
+ * display social profile fields, avatar image, etc.
+ *
+ * Usage:
+ *   const { uri } = useTokenURI(1n);
+ */
+export function useTokenURI(tokenId: bigint | undefined) {
+    const chainId = useChainId();
+    const address = getTNTAddress(chainId);
+
+    const { data, isLoading, error, refetch } = useReadContract({
+        address,
+        abi: TNT_ABI,
+        functionName: "tokenURI",
+        args: [tokenId!],
+        query: { enabled: !!address && tokenId !== undefined },
+    });
+
+    return { uri: data as string | undefined, isLoading, error, refetch } as const;
+}

--- a/lib/hooks/useTokenURI.ts
+++ b/lib/hooks/useTokenURI.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useReadContract, useChainId } from "wagmi";
-import TNT_ABI from "@/lib/abi/TNT.abi.json";
+import CLIENT_ABI from "@/lib/abi/TNT.client.abi.json";
 import { getTNTAddress } from "@/lib/contracts";
 
 /**
@@ -14,16 +14,21 @@ import { getTNTAddress } from "@/lib/contracts";
  *   const { uri } = useTokenURI(1n);
  */
 export function useTokenURI(tokenId: bigint | undefined) {
-    const chainId = useChainId();
-    const address = getTNTAddress(chainId);
+  const chainId = useChainId();
+  const address = getTNTAddress(chainId);
 
-    const { data, isLoading, error, refetch } = useReadContract({
-        address,
-        abi: TNT_ABI,
-        functionName: "tokenURI",
-        args: [tokenId!],
-        query: { enabled: !!address && tokenId !== undefined },
-    });
+  const { data, isLoading, error, refetch } = useReadContract({
+    address,
+    abi: CLIENT_ABI,
+    functionName: "tokenURI",
+    args: [tokenId!],
+    query: { enabled: !!address && tokenId !== undefined },
+  });
 
-    return { uri: data as string | undefined, isLoading, error, refetch } as const;
+  return {
+    uri: data as string | undefined,
+    isLoading,
+    error,
+    refetch,
+  } as const;
 }


### PR DESCRIPTION
## Summary
Adds the DIT frontend integration layer for on-chain TNT interactions.

### Changes
- Add TNT ABI under `lib/abi/TNT.abi.json`
- Add multi-chain contract config in `lib/contracts.ts`
- Add typed wagmi hooks for write/read contract operations
- Add hook barrel exports in `lib/hooks/index.ts`

### Hooks included
- Write: `useIssueIdentityToken`, `useSetAttribute`, `useSetTokenURI`, `useEndorseIdentity`, `useRevokeEndorsement`
- Read: `useGetEndorsements`, `useGetGivenEndorsements`, `useGetIdentityState`, `useGetAttribute`, `useTokenURI`

### Files
- `lib/abi/TNT.abi.json`
- `lib/contracts.ts`
- `lib/hooks/*`
- `lib/hooks/index.ts`

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issue identity tokens (mint new DITs).
  * Set and read custom token attributes.
  * Give and revoke endorsements between tokens.
  * Update and fetch token metadata URIs.
  * Retrieve full identity state (backup wallet, compromise status, pending backup).
  * Multi-network support: contract address resolution per chain and improved client APIs for on-chain interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->